### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "bootstrap": "^4.1.3",
     "firebase": "^5.4.2",
     "i": "^0.3.6",
-    "npm": "^6.4.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-icons": "^3.0.5",


### PR DESCRIPTION

Hello abrarzahin!

It seems like you have npm as one of your (dev-) dependency in Event-Master.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
